### PR TITLE
Add db-ping.dev wrapper script

### DIFF
--- a/db-ping.dev
+++ b/db-ping.dev
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# This wrapper script runs the in-development
+# version of db-ping from this directory.
+
+PYTHONPATH="$(dirname $0):$PYTHONPATH" python3 -m db_ping "$@"


### PR DESCRIPTION
This makes it easy to run the in-development version of db-ping from its
source directory or any other (e.g.
`/path/to/local-repos/db-ping/db-ping.dev` or `./db-ping.dev`).

See discussion at https://github.com/ottok/db-ping/pull/2#issuecomment-990681538